### PR TITLE
fix(solicitudes): folio se ve completo

### DIFF
--- a/apps/siiges-app/pages/solicitudes/index.jsx
+++ b/apps/siiges-app/pages/solicitudes/index.jsx
@@ -11,10 +11,10 @@ import {
 import { Divider } from '@mui/material';
 
 const columns = [
-  { field: 'folio', headerName: 'Folio', width: 100 },
+  { field: 'folio', headerName: 'Folio', width: 125 },
   { field: 'studyPlan', headerName: 'Plan de estudios', width: 350 },
   { field: 'estatusSolicitudId', headerName: 'Estatus', width: 120 },
-  { field: 'plantel', headerName: 'Plantel', width: 370 },
+  { field: 'plantel', headerName: 'Plantel', width: 345 },
   { field: 'actions', headerName: 'Acciones', width: 150 },
 ];
 


### PR DESCRIPTION
Esto podría ser un fix temporal, ya que se debería definir un número de caracteres máximo para el apartado de "Folio" (y cualquier otro apartado que requiera que se vea la información completa dentro de la tabla) para así ajustar la columna a el número de pixeles necesarios para que todo carácter pueda verse.

En caso de que no exista un límite, implementar una funcion para que las columnas se ajuste segun a la linea más larga