### PR TITLE
Guardado de observaciones - SDT 523

### DIFF
--- a/packages/shared/src/styles/buttons/ButtonAdd.css
+++ b/packages/shared/src/styles/buttons/ButtonAdd.css
@@ -66,10 +66,10 @@
 }
 
 .buttonAdd.enviar {
-  border-color: #11ce00;
+  border-color: orange;
 }
 
 .buttonAdd.enviar:hover {
-  background-color: #11ce00;
+  background-color: orange;
 }
 

--- a/packages/solicitudes/src/components/Modal/ModalObservacion.jsx
+++ b/packages/solicitudes/src/components/Modal/ModalObservacion.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable max-len */
 import { Grid, Typography } from '@mui/material';
 import { useRouter } from 'next/router';
 import {
@@ -55,12 +56,12 @@ function Modal({
 
   const confirmDocument = () => {
     setMethod('POST');
-    setDataBody([]);
+    setDataBody({});
     setEndpoint(`api/v1/solicitudes/${id}/observaciones`);
   };
   const confirmDocumentWithoutObservations = () => {
     setMethod('PATCH');
-    setDataBody({ estatusSolicitudId: 7 });
+    setDataBody({ estatusSolicitudId: 3 });
     setEndpoint(`api/v1/solicitudes/${id}`);
   };
 
@@ -73,8 +74,7 @@ function Modal({
       <Grid container spacing={2}>
         <Grid item xs={6}>
           <Typography variant="p" sx={{ fontWeight: 'bold' }}>
-            Desea terminar la revisión de la documentación? La institución sera
-            notificada.
+            ¿Está listo para finalizar la revisión de la solicitud? En caso de que haya observaciones, la institución será notificada.
           </Typography>
         </Grid>
       </Grid>
@@ -90,17 +90,17 @@ function Modal({
         <Grid item>
           <ButtonUnstyled
             className="buttonAdd enviar"
-            onClick={() => confirmDocumentWithoutObservations()}
+            onClick={() => confirmDocument()}
           >
-            Enviar sin observaciones
+            Enviar Observaciones
           </ButtonUnstyled>
         </Grid>
         <Grid item>
           <ButtonUnstyled
             className="buttonAdd guardar"
-            onClick={() => confirmDocument()}
+            onClick={() => confirmDocumentWithoutObservations()}
           >
-            Guardar
+            Aprobar Revisión
           </ButtonUnstyled>
         </Grid>
       </Grid>

--- a/packages/solicitudes/src/components/ModuleHeader/index.jsx
+++ b/packages/solicitudes/src/components/ModuleHeader/index.jsx
@@ -31,9 +31,12 @@ export default function ModuleHeader({
   const router = useRouter();
 
   const isControlDocumental = rol === 'control_documental';
+  const isFinalModule = module === steps.length - 1;
+  const textIsControlDocumental = isFinalModule ? 'Terminar revisión' : 'Siguiente modulo';
+  const textNormal = isFinalModule ? 'Terminar solicitud' : 'Siguiente modulo';
   const textRol = isControlDocumental
-    ? 'Terminar revisión'
-    : 'Terminar solicitud';
+    ? textIsControlDocumental
+    : textNormal;
 
   const handleLastStepAction = async () => {
     setModalRepresentante(false);
@@ -77,7 +80,11 @@ export default function ModuleHeader({
         });
       }
     } else if (isControlDocumental) {
-      setModalState({ open: true, title: 'Enviar Observaciones' });
+      if (isFinalModule) {
+        setModalState({ open: true, title: 'Enviar Observaciones' });
+      } else {
+        nextModule();
+      }
     } else {
       nextModule();
     }

--- a/packages/solicitudes/src/components/NuevaSolicitud/Anexos/index.jsx
+++ b/packages/solicitudes/src/components/NuevaSolicitud/Anexos/index.jsx
@@ -4,6 +4,7 @@ import { Card, CardContent } from '@mui/material';
 import SectionLayout from '../../SectionLayout';
 import pagination from '../../../events/pagination';
 import AnexosSeccion from '../../Sections/AnexosSeccion';
+import Observaciones from '../../Sections/Observaciones';
 
 export default function Anexos({
   nextModule, id, type,
@@ -43,6 +44,10 @@ export default function Anexos({
               type={type}
             />
           )}
+          <Observaciones
+            id={id}
+            section={section + 18}
+          />
         </SectionLayout>
       </CardContent>
     </Card>

--- a/packages/solicitudes/src/components/NuevaSolicitud/DatosGenerales/index.jsx
+++ b/packages/solicitudes/src/components/NuevaSolicitud/DatosGenerales/index.jsx
@@ -7,6 +7,7 @@ import DiligenciasData from '../../Sections/DiligenciasData';
 import SectionLayout from '../../SectionLayout';
 import pagination from '../../../events/pagination';
 import { DatosGeneralesProvider } from '../../utils/Context/datosGeneralesContext';
+import Observaciones from '../../Sections/Observaciones';
 
 export default function DatosGenerales({
   nextModule, id,
@@ -32,6 +33,10 @@ export default function DatosGenerales({
             {section === 1 && <InstitucionData id={id} />}
             {section === 2 && <RepresentanteLegalData id={id} />}
             {section === 3 && <DiligenciasData id={id} />}
+            <Observaciones
+              id={id}
+              section={section + 9}
+            />
           </SectionLayout>
         </DatosGeneralesProvider>
       </CardContent>

--- a/packages/solicitudes/src/components/NuevaSolicitud/EvaluacionCurricular/index.jsx
+++ b/packages/solicitudes/src/components/NuevaSolicitud/EvaluacionCurricular/index.jsx
@@ -5,6 +5,7 @@ import SectionLayout from '../../SectionLayout';
 import pagination from '../../../events/pagination';
 import DatosGeneralesEvaluacion from '../../Sections/DatosGeneralesEvaluacion';
 import { EvaluacionCurricularProvider } from '../../utils/Context/evaluacionCurricularContext';
+import Observaciones from '../../Sections/Observaciones';
 
 export default function EvaluacionCurricular({
   nextModule,
@@ -41,6 +42,10 @@ export default function EvaluacionCurricular({
             {section === 1 && (
               <DatosGeneralesEvaluacion disabled={disabled} id={id} type={type} />
             )}
+            <Observaciones
+              id={id}
+              section={section + 19}
+            />
           </SectionLayout>
         </EvaluacionCurricularProvider>
       </CardContent>

--- a/packages/solicitudes/src/components/NuevaSolicitud/PlanEstudios/index.jsx
+++ b/packages/solicitudes/src/components/NuevaSolicitud/PlanEstudios/index.jsx
@@ -202,7 +202,6 @@ export default function PlanEstudios({
                 <Observaciones
                   id={id}
                   section={section === 1 ? section : section + 1}
-                  rol={session?.rol}
                 />
               )}
             </SectionLayout>

--- a/packages/solicitudes/src/components/NuevaSolicitud/Plantel/index.jsx
+++ b/packages/solicitudes/src/components/NuevaSolicitud/Plantel/index.jsx
@@ -14,6 +14,7 @@ import RatificacionNombre from '../../Sections/RatificacionNombre';
 import NombresPropuestos from '../../Sections/NombresPropuestos';
 import { PlantelProvider } from '../../utils/Context/plantelContext';
 import getSolicitudesById from '../../utils/getSolicitudesById';
+import Observaciones from '../../Sections/Observaciones';
 
 export default function Plantel({
   nextModule,
@@ -108,6 +109,10 @@ export default function Plantel({
               <Infraestructura disabled={disabled} programaId={programaId} />
             )}
             {renderSection6()}
+            <Observaciones
+              id={id}
+              section={section + 12}
+            />
           </SectionLayout>
         </PlantelProvider>
       </CardContent>

--- a/packages/solicitudes/src/components/SectionLayout/ButtonSection.jsx
+++ b/packages/solicitudes/src/components/SectionLayout/ButtonSection.jsx
@@ -68,19 +68,6 @@ export default function ButtonSection({
     }
   }
 
-  const PlanDeEstudios = () => {
-    if (isControlDocumental) {
-      return () => observaciones();
-    }
-    return {
-      1: () => validateNewSolicitud(),
-      3: () => submitEditSolicitud(validations, sections, id, setLoading),
-      4: () => submitEditSolicitud(validations, sections, id, setLoading),
-      5: () => submitEditSolicitud(validations, sections, id, setLoading),
-      9: () => submitTrayectoriaEducativa(validations, setLoading),
-    };
-  };
-
   const sectionFunctions = {
     'Datos Generales': {
       1: useCallback(
@@ -127,9 +114,20 @@ export default function ButtonSection({
     'Evaluación Curricular': {
       1: () => submitEvaluacionCurricular(evaluacionCurricular, setNoti, setLoading),
     },
-    'Plan de estudios': PlanDeEstudios(),
+    'Plan de estudios': {
+      1: () => validateNewSolicitud(),
+      3: () => submitEditSolicitud(validations, sections, id, setLoading),
+      4: () => submitEditSolicitud(validations, sections, id, setLoading),
+      5: () => submitEditSolicitud(validations, sections, id, setLoading),
+      9: () => submitTrayectoriaEducativa(validations, setLoading),
+    },
   };
-  if (sectionFunctions[sectionTitle]) {
+  if (isControlDocumental) {
+    submit = () => {
+      observaciones();
+    };
+  }
+  if (sectionFunctions[sectionTitle] && !isControlDocumental) {
     if (typeof sectionFunctions[sectionTitle] === 'function') {
       submit = () => {
         setLoading(true);
@@ -217,8 +215,8 @@ export default function ButtonSection({
         <Grid container spacing={1} sx={{ textAlign: 'right', mt: 0.5 }}>
           <Grid item xs={12}>
             <ButtonStyled
-              text="Terminar solicitud"
-              alt="Terminar solicitud"
+              text={buttonTextEnd}
+              alt={buttonTextEnd}
               type="success"
               onclick={!loading ? submit : null}
             />

--- a/packages/solicitudes/src/components/Sections/Observaciones.jsx
+++ b/packages/solicitudes/src/components/Sections/Observaciones.jsx
@@ -2,20 +2,21 @@ import { Grid, TextField, Typography } from '@mui/material';
 import { useApi, LabelData, Context } from '@siiges-ui/shared';
 import React, { useEffect, useState, useContext } from 'react';
 import PropTypes from 'prop-types';
-import { TablesPlanEstudiosContext } from '../utils/Context/tablesPlanEstudiosProviderContext';
+import { ObservacionesContext } from '../utils/Context/observacionesContext';
 
-function Observaciones({ id, section, rol }) {
+function Observaciones({ id, section }) {
   const {
     createObservaciones,
     setCreateObservaciones,
-  } = useContext(TablesPlanEstudiosContext);
-  const { setNoti } = useContext(Context);
+  } = useContext(ObservacionesContext);
+  const { setNoti, session, setLoading } = useContext(Context);
+  const { rol } = session;
   const [path, setPath] = useState('');
   const [body, setBody] = useState(null);
   const [method, setMethod] = useState('GET');
   const [observaciones, setObservaciones] = useState('');
 
-  const { data, error } = useApi({
+  const { data, error, loading } = useApi({
     endpoint: path,
     dataBody: body,
     method,
@@ -43,16 +44,15 @@ function Observaciones({ id, section, rol }) {
   }, [section, id, method]);
 
   useEffect(() => {
-    if (method === 'POST') {
-      setMethod('GET');
-      setCreateObservaciones(false);
-    }
+    setLoading(loading);
     if (method === 'POST' && error) {
       setNoti({
         open: true,
         message: 'Error al guardar observaciones',
         type: 'error',
       });
+      setMethod('GET');
+      setCreateObservaciones(false);
     }
     if (method === 'POST' && data) {
       setNoti({
@@ -60,8 +60,10 @@ function Observaciones({ id, section, rol }) {
         message: 'Observaciones guardadas',
         type: 'success',
       });
+      setMethod('GET');
+      setCreateObservaciones(false);
     }
-  }, [method]);
+  }, [loading]);
 
   useEffect(() => {
     if (method === 'GET' && data) {
@@ -110,5 +112,4 @@ Observaciones.propTypes = {
     PropTypes.string,
   ]),
   section: PropTypes.number.isRequired,
-  rol: PropTypes.string.isRequired,
 };


### PR DESCRIPTION

**Descripción**: Hemos identificado un problema en la funcionalidad de guardado de observaciones que afecta tanto al frontend como al backend de nuestra aplicación. Actualmente, sólo es posible guardar observaciones en el primer apartado de la interfaz, cuando debería ser posible hacerlo en todos los apartados disponibles.

**Pasos para reproducir**:

1.  Acceder a la sección donde se ingresan las observaciones.
    
2.  Intentar añadir observaciones en cualquier apartado después del primero.
    
3.  Intentar guardar las observaciones.
    

**Comportamiento esperado**: El usuario debería poder ingresar y guardar observaciones en todos los apartados disponibles sin restricciones.

**Comportamiento actual**: Las observaciones solo se pueden añadir y guardar en el primer apartado. Los intentos de guardar en otros apartados no tienen éxito y el proceso de guardado no se completa adecuadamente, resultando en un fallo que impide la correcta funcionalidad del guardado.

**Impacto**: Este problema impide que los usuarios utilicen la funcionalidad de observaciones como se espera, lo que puede afectar la recolección de información importante para el proceso operativo.

**Áreas afectadas**:

-   Frontend: Problemas en la interfaz de usuario que impiden la entrada de datos en múltiples secciones.
    
-   Backend: La lógica de guardado no procesa correctamente los datos de todas las secciones.
    

**Entorno**:

-   [Incluir detalles del entorno, como el navegador y la versión, cualquier framework o librería relevante, etc.]