### PR TITLE
SDT- cambio de color boton preregistro

### DIFF
--- a/packages/shared/src/components/Navbar/index.jsx
+++ b/packages/shared/src/components/Navbar/index.jsx
@@ -43,7 +43,7 @@ export default function Navbar() {
               sx={{
                 backgroundColor: 'rgba(233, 236, 239, 0.5)',
                 textTransform: 'none',
-                color: 'white',
+                color: 'black',
                 borderRadius: '2rem',
                 '&:hover': {
                   background: '#fff',

--- a/packages/shared/src/utils/mocks/estadosMexico.js
+++ b/packages/shared/src/utils/mocks/estadosMexico.js
@@ -31,6 +31,7 @@ const estadosMexico = [
   { id: 30, nombre: 'Veracruz de Ignacio de la LLave' },
   { id: 31, nombre: 'Yucatán' },
   { id: 32, nombre: 'Zacatecas' },
+  { id: 33, nombre: 'Extranjero' },
 ];
 
 export default estadosMexico;


### PR DESCRIPTION
solo cambio de color del boton de preregistro de blanco a negro y del listado del apartado de estado de procedencia poner extranjero u OTRO