### PR TITLE
SDT-1165: añadido el setup de los prefijos en los commits

### DIFF
--- a/.hooks/commit-msg
+++ b/.hooks/commit-msg
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# Regex: ticket tipo ABC-1234 o commits de merge
+commit_regex="^([A-Z]+-[0-9]+:|Merge)"
+
+if ! grep -iqE "$commit_regex" "$1"; then
+    echo "❌ Commit abortado: El mensaje debe iniciar con un ticket (ej: SDT-1234:) o 'Merge'" >&2
+    exit 1
+fi

--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -1,0 +1,51 @@
+#!/bin/bash
+ 
+STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep ".jsx\{0,1\}$")
+ESLINT="$(git rev-parse --show-toplevel)/node_modules/.bin/eslint"
+ 
+if [[ "$STAGED_FILES" = "" ]]; then
+  exit 0
+fi
+ 
+PASS=true
+ 
+printf "\nValidating Javascript:\n"
+ 
+# Check for eslint
+if [[ ! -x "$ESLINT" ]]; then
+  printf "\t\033[41mPlease install ESlint\033[0m (npm i --save-dev eslint)"
+  exit 1
+fi
+ 
+for FILE in $STAGED_FILES
+do
+  "$ESLINT" "$FILE"
+ 
+  if [[ "$?" == 0 ]]; then
+    printf "\t\033[32mESLint Passed: $FILE\033[0m"
+  else
+    printf "\t\033[41mESLint Failed: $FILE\033[0m"
+    PASS=false
+  fi
+done
+ 
+printf "\nJavascript validation completed!\n"
+
+printf "\nRunning tests:\n"
+npm run test:cov
+if [[ "$?" == 0 ]]; then
+  printf "\t\033[32mTests Passed\n\033[0m"
+  else
+    printf "\t\033[41mTests Failed\n\033[0m"
+    PASS=false
+fi
+
+if ! $PASS; then
+  printf "\033[41mCOMMIT FAILED:\033[0m Your commit contains files that should pass tests and ESLint but do not. Please fix the failing tests / ESLint errors and try again.\n"
+  exit 1
+else
+  printf "\033[42mCOMMIT SUCCEEDED\033[0m\n"
+fi
+
+ 
+exit $?

--- a/.hooks/prepare-commit-msg
+++ b/.hooks/prepare-commit-msg
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Obtiene el nombre de la rama actual
+branch="$(git branch --show-current)"
+msg="$(cat "$1")"
+
+# Extrae ticket tipo ABC-1234 del nombre de la rama
+prefix=$(echo "$branch" | grep -oE '[A-Z]+-[0-9]+')
+
+# Si hay ticket y no está ya en el mensaje, lo agrega
+if [[ -n "$prefix" ]]; then
+  if [[ "$msg" != "$prefix: "* ]]; then
+    echo "$prefix: $msg" > "$1"
+  fi
+fi

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
 		"test": "jest",
 		"test:watch": "jest --watch",
 		"postinstall": "",
-		"dev": "cd apps/siiges-app && yarn dev"
+		"dev": "cd apps/siiges-app && yarn dev",
+		"setup": "git config core.hooksPath .hooks"
 	},
 	"dependencies": {
 		"@babel/cli": "^7.18.9",


### PR DESCRIPTION
se requiere ejecutar "yarn setup" para que quede funcionando, 
este PR automaticamente añadira el prefijo con el nombre de la rama a los commits, ej:
"añadido el setup de los prefijos en los commits" -> "SDT-1165: añadido el setup de los prefijos en los commits"