### PR TITLE
SDT-1179: correcciones asignaturas en programas y acreditacion

### DIFF
--- a/packages/serviciosEscolares/src/Components/utils/AsignaturasEditModal.jsx
+++ b/packages/serviciosEscolares/src/Components/utils/AsignaturasEditModal.jsx
@@ -47,6 +47,19 @@ export default function AsignaturasEditModal({
   }, [cicloId]);
 
   useEffect(() => {
+    let seriacionValue = rowItem.seriacion;
+
+    if (seriacionValue) {
+      const match = asignaturasList.find(
+        (seriacion) => seriacion.clave === seriacionValue || seriacion.nombre === seriacionValue,
+      );
+      if (match) {
+        seriacionValue = match.nombre;
+      }
+    }
+
+    console.log('Seriacion nombre: ', seriacionValue);
+
     const rowItemValues = {
       id: rowItem.id,
       gradoId: rowItem.gradoId,
@@ -56,7 +69,7 @@ export default function AsignaturasEditModal({
       clave: rowItem.clave,
       creditos: rowItem.creditos,
       academia: rowItem.academia,
-      seriacion: rowItem.seriacion,
+      seriacion: seriacionValue,
       horasDocente: rowItem.horasDocente,
       horasIndependiente: rowItem.horasIndependiente,
     };
@@ -221,11 +234,12 @@ export default function AsignaturasEditModal({
             title="Seriación"
             name="seriacion"
             value={formAsignaturas.seriacion || ''}
-            options={[{ value: '', label: '' }, ...(asignaturasList || [])]}
+            options={asignaturasList || []}
             disabled={edit === 'Consultar Asignatura'}
             onChange={handleOnChange}
             textValue
           />
+
         </Grid>
         <Grid item xs={6}>
           <Input

--- a/packages/serviciosEscolares/src/Components/utils/AsignaturasEditModal.jsx
+++ b/packages/serviciosEscolares/src/Components/utils/AsignaturasEditModal.jsx
@@ -58,8 +58,6 @@ export default function AsignaturasEditModal({
       }
     }
 
-    console.log('Seriacion nombre: ', seriacionValue);
-
     const rowItemValues = {
       id: rowItem.id,
       gradoId: rowItem.gradoId,
@@ -126,6 +124,11 @@ export default function AsignaturasEditModal({
       setLoading,
     );
   };
+
+  const seriacionOptions = asignaturasList.map((asignatura) => ({
+    id: asignatura.id,
+    nombre: asignatura.clave,
+  }));
 
   const cancelButtonText = edit === 'Consultar Asignatura' ? 'Regresar' : 'Cancelar';
 
@@ -234,7 +237,7 @@ export default function AsignaturasEditModal({
             title="Seriación"
             name="seriacion"
             value={formAsignaturas.seriacion || ''}
-            options={asignaturasList || []}
+            options={seriacionOptions || []}
             disabled={edit === 'Consultar Asignatura'}
             onChange={handleOnChange}
             textValue
@@ -304,7 +307,13 @@ AsignaturasEditModal.propTypes = {
     horasIndependiente: PropTypes.number,
   }).isRequired,
   programaId: PropTypes.number.isRequired,
-  asignaturasList: PropTypes.arrayOf(PropTypes.string).isRequired,
+  asignaturasList: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.number.isRequired,
+      nombre: PropTypes.string.isRequired,
+      clave: PropTypes.string.isRequired,
+    }),
+  ).isRequired,
   setAsignaturasList: PropTypes.func.isRequired,
   setNoti: PropTypes.func.isRequired,
   setLoading: PropTypes.func.isRequired,

--- a/packages/serviciosEscolares/src/Components/utils/Calificaciones/CalificacionExtraInput.jsx
+++ b/packages/serviciosEscolares/src/Components/utils/Calificaciones/CalificacionExtraInput.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/jsx-props-no-spreading */
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { Autocomplete, TextField, Box } from '@mui/material';
@@ -99,6 +100,7 @@ export default function CalificacionExtraInput({
         disabled={disabled}
         renderInput={(params) => (
           <TextField
+            {...params}
             id={params.id}
             inputRef={params.InputProps.ref}
             InputProps={params.InputProps}


### PR DESCRIPTION
Se corrigio que en programas -> asignaturas -> seriacion donde no se mostraba el nombre de la asignatura de seriacion cuando se intentaba editar y consultar

Tambien se corrigio el input con select opcional que aparece en acreditacion -> asignaturas -> calificacion extraordinaria donde no se mostraba el menu de opciones con valores predeterminados