### PR TITLE
SDT-1579: busqueda de alumnos parte 1

### DIFF
--- a/apps/siiges-app/pages/serviciosEscolares/alumnos/busquedaAlumnos/index.jsx
+++ b/apps/siiges-app/pages/serviciosEscolares/alumnos/busquedaAlumnos/index.jsx
@@ -1,0 +1,60 @@
+import { Layout } from '@siiges-ui/shared';
+import {
+  BusquedaAlumnosForm,
+  BusquedaAlumnosTable,
+} from '@siiges-ui/serviciosescolares';
+import { Divider, Grid } from '@mui/material';
+import React from 'react';
+
+const alumnosMock = [
+  {
+    id: 1,
+    nombreCompleto: 'Nombre Apellido1 Apellido2',
+    curp: 'CURPXXXXXXXX01',
+    claveTrabajo: 'TSU2026HOY',
+    programa: 'Diseño de interiores en Teotihuacan',
+    matricula: '20260001',
+  },
+  {
+    id: 2,
+    nombreCompleto: 'Nombre Apellido1 Apellido2',
+    curp: 'CURPXXXXXXXX02',
+    claveTrabajo: 'TSU2026HOY',
+    programa: 'Psicologia',
+    matricula: '20260002',
+  },
+  {
+    id: 3,
+    nombreCompleto: 'Nombre Apellido1 Apellido2',
+    curp: 'CURPXXXXXXXX03',
+    claveTrabajo: 'TSU2026HOY',
+    programa: 'Psicologia',
+    matricula: '20260003',
+  },
+  {
+    id: 4,
+    nombreCompleto: 'Nombre Apellido1 Apellido2',
+    curp: 'CURPXXXXXXXX04',
+    claveTrabajo: 'TSU2026HOY',
+    programa: 'Psicologia',
+    matricula: '20260004',
+  },
+];
+
+export default function BusquedaAlumnos() {
+  return (
+    <Layout title="Busqueda de Alumnos">
+      <Grid container>
+        <Grid item xs={12}>
+          <BusquedaAlumnosForm />
+        </Grid>
+        <Grid item xs={12}>
+          <Divider sx={{ marginTop: 2 }} />
+        </Grid>
+        <Grid item xs={12}>
+          <BusquedaAlumnosTable alumnos={alumnosMock} />
+        </Grid>
+      </Grid>
+    </Layout>
+  );
+}

--- a/packages/serviciosEscolares/src/Components/Alumnos/BusquedaAlumnos/Form/index.jsx
+++ b/packages/serviciosEscolares/src/Components/Alumnos/BusquedaAlumnos/Form/index.jsx
@@ -1,0 +1,38 @@
+import { Grid } from '@mui/material';
+import { ButtonSimple, Input } from '@siiges-ui/shared';
+import SearchIcon from '@mui/icons-material/Search';
+import React from 'react';
+
+export default function BusquedaAlumnosForm() {
+  return (
+    <Grid container spacing={2}>
+      <Grid item xs={3}>
+        <Input id="nombre" name="nombre" label="Nombre" />
+      </Grid>
+      <Grid item xs={3}>
+        <Input id="apellidoPaterno" name="apellidoPaterno" label="Apellido Paterno" />
+      </Grid>
+      <Grid item xs={3}>
+        <Input id="apellidoMaterno" name="apellidoMaterno" label="Apellido Materno" />
+      </Grid>
+      <Grid item xs={3}>
+        <Input id="curp" name="curp" label="CURP" />
+      </Grid>
+      <Grid item xs={6}>
+        <Input id="claveCentroTrabajo" name="claveCentroTrabajo" label="Clave Centro Trabajo" />
+      </Grid>
+      <Grid item xs={3}>
+        <Input id="matricula" name="matricula" label="Matricula" />
+      </Grid>
+      <Grid item xs={3} sx={{ display: 'flex', alignItems: 'center' }}>
+        <ButtonSimple
+          text="Buscar"
+          onClick={() => {}}
+          design="buscar"
+        >
+          <SearchIcon />
+        </ButtonSimple>
+      </Grid>
+    </Grid>
+  );
+}

--- a/packages/serviciosEscolares/src/Components/Alumnos/BusquedaAlumnos/Form/index.jsx
+++ b/packages/serviciosEscolares/src/Components/Alumnos/BusquedaAlumnos/Form/index.jsx
@@ -29,6 +29,7 @@ export default function BusquedaAlumnosForm() {
           text="Buscar"
           onClick={() => {}}
           design="buscar"
+          fullWidth
         >
           <SearchIcon />
         </ButtonSimple>

--- a/packages/serviciosEscolares/src/Components/Alumnos/BusquedaAlumnos/Table/index.jsx
+++ b/packages/serviciosEscolares/src/Components/Alumnos/BusquedaAlumnos/Table/index.jsx
@@ -1,0 +1,80 @@
+import { Grid } from '@mui/material';
+import { DataTable } from '@siiges-ui/shared';
+import IconButton from '@mui/material/IconButton';
+import SearchIcon from '@mui/icons-material/Search';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+const columns = (handleVerDetalle) => [
+  {
+    field: 'nombreCompleto',
+    headerName: 'Nombre Completo',
+    width: 300,
+  },
+  {
+    field: 'curp',
+    headerName: 'CURP',
+    width: 150,
+  },
+  {
+    field: 'claveTrabajo',
+    headerName: 'Clave de trabajo',
+    width: 150,
+  },
+  {
+    field: 'programa',
+    headerName: 'Programa',
+    width: 250,
+  },
+  {
+    field: 'matricula',
+    headerName: 'Matricula',
+    width: 150,
+  },
+  {
+    field: 'acciones',
+    headerName: 'Acciones',
+    width: 100,
+    sortable: false,
+    renderCell: (params) => (
+      <IconButton onClick={() => handleVerDetalle(params.row)}>
+        <SearchIcon />
+      </IconButton>
+    ),
+  },
+];
+
+export default function BusquedaAlumnosTable({ alumnos }) {
+  const handleVerDetalle = (alumno) => {
+    console.log('Ver detalle de alumno:', alumno);
+  };
+
+  return (
+    <Grid container spacing={2}>
+      <Grid item xs={12}>
+        <DataTable
+          title="Alumnos"
+          columns={columns(handleVerDetalle)}
+          rows={alumnos}
+        />
+      </Grid>
+    </Grid>
+  );
+}
+
+BusquedaAlumnosTable.defaultProps = {
+  alumnos: [],
+};
+
+BusquedaAlumnosTable.propTypes = {
+  alumnos: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.number.isRequired,
+      nombreCompleto: PropTypes.string,
+      curp: PropTypes.string,
+      claveTrabajo: PropTypes.string,
+      programa: PropTypes.string,
+      matricula: PropTypes.string,
+    }),
+  ),
+};

--- a/packages/serviciosEscolares/src/index.js
+++ b/packages/serviciosEscolares/src/index.js
@@ -56,8 +56,12 @@ import TitulosForm from './Components/Titulacion/TitulosForm/index';
 import TitulosTable from './Components/Titulacion/catalogoTitulosTable';
 import catalogoTitulos from './Tables/catalogoTitulosTable';
 import AlumnosData from './Components/Alumnos/AlumnosData';
+import BusquedaAlumnosForm from './Components/Alumnos/BusquedaAlumnos/Form';
+import BusquedaAlumnosTable from './Components/Alumnos/BusquedaAlumnos/Table';
 
 export {
+  BusquedaAlumnosForm,
+  BusquedaAlumnosTable,
   ExpedienteAlumno,
   catalogoTitulos,
   TitulosTable,

--- a/packages/shared/src/components/Buttons/ButtonSimple.jsx
+++ b/packages/shared/src/components/Buttons/ButtonSimple.jsx
@@ -14,12 +14,13 @@ export default function ButtonSimple({
 
   return (
     <Grid container justifyContent={justifyContent}>
-      <Grid item>
+      <Grid item sx={{ width: '100%' }}>
         <Button
           onClick={onClick}
           className={`buttonAdd ${design}`}
           variant="text"
           disabled={disabled}
+          fullWidth
         >
           <Typography variant="body1" style={{ textTransform: 'none' }}>
             {text}

--- a/packages/shared/src/components/Buttons/ButtonSimple.jsx
+++ b/packages/shared/src/components/Buttons/ButtonSimple.jsx
@@ -4,7 +4,7 @@ import { Typography, Grid, Button } from '@mui/material';
 import '../../styles/buttons/ButtonAdd.css';
 
 export default function ButtonSimple({
-  text, onClick, align, design, children, disabled,
+  text, onClick, align, design, children, disabled, fullWidth,
 }) {
   const justifyContent = {
     left: 'flex-start',
@@ -14,13 +14,13 @@ export default function ButtonSimple({
 
   return (
     <Grid container justifyContent={justifyContent}>
-      <Grid item sx={{ width: '100%' }}>
+      <Grid item sx={{ width: fullWidth ? '100%' : 'auto' }}>
         <Button
           onClick={onClick}
           className={`buttonAdd ${design}`}
           variant="text"
           disabled={disabled}
-          fullWidth
+          fullWidth={fullWidth}
         >
           <Typography variant="body1" style={{ textTransform: 'none' }}>
             {text}
@@ -38,13 +38,15 @@ ButtonSimple.defaultProps = {
   onClick: () => {},
   children: null,
   disabled: false,
+  fullWidth: false,
 };
 
 ButtonSimple.propTypes = {
   onClick: PropTypes.func,
   text: PropTypes.string.isRequired,
   design: PropTypes.string,
-  disabled: PropTypes.string,
+  disabled: PropTypes.bool,
+  fullWidth: PropTypes.bool,
   align: PropTypes.oneOf(['left', 'center', 'right']),
   children: PropTypes.node,
 };

--- a/packages/shared/src/components/Drawer/utils/menuUsers.jsx
+++ b/packages/shared/src/components/Drawer/utils/menuUsers.jsx
@@ -189,6 +189,14 @@ const panelMenuOptions = (rol, nombre) => {
     ] : []),
 
     {
+      userId: 2,
+      text: 'Busqueda de Alumnos',
+      icon: <AssignmentIcon />,
+      route: '/serviciosEscolares/alumnos/busquedaAlumnos',
+      key: 'busquedaAlumnos',
+    },
+
+    {
       userId: 3,
       text: 'Instituciones',
       icon: <BusinessIcon />,

--- a/packages/shared/src/styles/buttons/ButtonAdd.css
+++ b/packages/shared/src/styles/buttons/ButtonAdd.css
@@ -76,3 +76,22 @@
   background-color: #FF8300;
 }
 
+.buttonAdd.buscar {
+  border-color: #FF8300;
+  justify-content: space-between;
+  padding-left: 16px;
+  padding-right: 16px;
+  width: 100%;
+}
+
+.buttonAdd.buscar:hover {
+  background-color: #FF8300;
+}
+
+.buttonAdd.buscar:disabled {
+  pointer-events: none;
+  border-color: gray;
+  background-color: gray;
+  color: white;
+}
+


### PR DESCRIPTION
Crear pantallas donde se puedan visualizar Alumnos mediante el filtrado de información sin importar el Programa, CT o Institución.

Parámetros de Busqueda

-Nombre
-Apellido Paterno
-Apellido Materno
-Curp
-CT
-Matricula

Función: Se llenaran los campos de Filtrado, mínimo 1, para poder mostrar el alumno o los alumnos resultado de la búsqueda, entre mas campos se llenen mayor el filtrado, en caso de las ies tendrán por defecto el campo CT ya por default y no podrán quitarlo, esto con el fin de que cada institución pueda ver solo a sus alumnos. En la parte inferior aparecerá el listado resultado de la búsqueda.

Edit: hay 1 console.log y datos mockeados porque el endpoint aun no existe xd