### PR TITLE
SDT-1609: Update PlantelContext to ensure default context fallback

### DIFF
--- a/packages/shared/src/contexts/PlantelContext.jsx
+++ b/packages/shared/src/contexts/PlantelContext.jsx
@@ -11,10 +11,7 @@ const PlantelContext = createContext();
  */
 export const usePlantel = () => {
   const context = useContext(PlantelContext);
-  if (context === undefined) {
-    throw new Error('usePlantel debe ser usado dentro de un PlantelProvider');
-  }
-  return context;
+  return context ?? {};
 };
 
 export function PlantelProvider({ children, selectedPlantel, institucion }) {


### PR DESCRIPTION
**Purpose of the Change**
The update ensures that the usePlantel hook in PlantelContext provides a default fallback context to prevent potential errors when the context is used outside of its provider.

---
**What Changed**
Modified the usePlantel hook to return an empty object ({}) as a fallback when the context is null or undefined.

---
**Summary**
This update modifies the usePlantel hook in PlantelContext to provide a default fallback context ({}) when the context is not available. This change prevents potential runtime errors when the hook is used outside of its provider.